### PR TITLE
Added a request URI

### DIFF
--- a/src/ServerRequestFactoryTest.php
+++ b/src/ServerRequestFactoryTest.php
@@ -67,10 +67,11 @@ class ServerRequestFactoryTest extends TestCase
     public function testCreateServerRequestFromGlobals()
     {
         $_SERVER['REQUEST_METHOD'] = $method = 'GET';
+        $_SERVER['REQUEST_URI'] = $path = '/test';
         $_SERVER['QUERY_STRING'] = $qs = 'foo=1&bar=true';
         $_SERVER['HTTP_HOST'] = $host = 'example.org';
 
-        $uri = "http://{$host}/?$qs";
+        $uri = "http://{$host}{$path}?$qs";
 
         $request = $this->factory->createServerRequestFromGlobals();
 


### PR DESCRIPTION
The request URI was added as a workaround for some implementation not using a tailoring slash if the request uri was missing.

Related to https://github.com/http-interop/http-factory-guzzle/issues/2
