### PR TITLE
Fix test case namespace

### DIFF
--- a/test/StreamFactoryTest.php
+++ b/test/StreamFactoryTest.php
@@ -3,10 +3,13 @@
 namespace Interop\Http\Factory;
 
 use Interop\Http\Factory\StreamFactoryInterface;
+use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\StreamInterface;
 
 class StreamFactoryTest extends TestCase
 {
+    use StreamHelper;
+
     /** @var  StreamFactoryInterface */
     private $factory;
 

--- a/test/StreamHelper.php
+++ b/test/StreamHelper.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Http\FactoryTest;
+namespace Interop\Http\Factory;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+trait StreamHelper
 {
     protected function createTemporaryFile()
     {

--- a/test/UploadedFileFactoryTest.php
+++ b/test/UploadedFileFactoryTest.php
@@ -2,10 +2,13 @@
 
 namespace Interop\Http\Factory;
 
+use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\UploadedFileInterface;
 
 class UploadedFileFactoryTest extends TestCase
 {
+    use StreamHelper;
+
     /** @var  UploadedFileInterface */
     private $factory;
 


### PR DESCRIPTION
This PR contains two changes:

- Fixes the namespace issue for the TestCase (StreamHelper) class introduced in #6 
- Removes the namespace aliasing as I think it is rather confusing
