### PR TITLE
Enable autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7"
     },
-    "autoload-dev": {
+    "autoload": {
         "psr-4": {
             "Interop\\Http\\Factory\\": "test/"
         }


### PR DESCRIPTION
This is necessary because of the newly introduced TestCase classes