### PR TITLE
Fix invalid URI test

### DIFF
--- a/test/UriFactoryTestCase.php
+++ b/test/UriFactoryTestCase.php
@@ -43,6 +43,6 @@ abstract class UriFactoryTestCase extends TestCase
      */
     public function testExceptionWhenUriIsInvalid()
     {
-        $this->factory->createUri('\Invalid\Uri');
+        $this->factory->createUri(':');
     }
 }


### PR DESCRIPTION
Looks like parse_url accepts any kind of insane values