### PR TITLE
Allow non-empty server params

### DIFF
--- a/test/ServerRequestFactoryTestCase.php
+++ b/test/ServerRequestFactoryTestCase.php
@@ -126,7 +126,10 @@ abstract class ServerRequestFactoryTestCase extends TestCase
 
         $request = $this->factory->createServerRequest([], 'POST', 'http://example.org/test');
 
-        $this->assertEmpty($request->getServerParams());
+        $serverParams = $request->getServerParams();
+
+        $this->assertNotEquals($_SERVER, $serverParams);
+        $this->assertArrayNotHasKey('HTTP_X_FOO', $serverParams);
     }
 
     public function testCreateServerRequestDoesNotReadCookieSuperglobal()


### PR DESCRIPTION
As per PSR-7:

```
    /**
     * Retrieve server parameters.
     *
     * Retrieves data related to the incoming request environment,
     * typically derived from PHP's $_SERVER superglobal. The data IS NOT
     * REQUIRED to originate from $_SERVER.
     *
     * @return array
     */
    public function getServerParams();
```