### PR TITLE
Fixes overwriting of _SERVER superglobal

### DIFF
--- a/test/ServerRequestFactoryTestCase.php
+++ b/test/ServerRequestFactoryTestCase.php
@@ -120,6 +120,9 @@ abstract class ServerRequestFactoryTestCase extends TestCase
         $this->assertServerRequest($request, $method, $uri);
     }
 
+    /**
+     * @backupGlobals enabled
+     */
     public function testCreateServerRequestDoesNotReadServerSuperglobal()
     {
         $_SERVER = ['HTTP_X_FOO' => 'bar'];


### PR DESCRIPTION
The test function for ServerRequest, that which ensures the _SERVER superglobal not be read, does so by blindly overwriting the _SERVER superglobal with a fake header. This can cause issues with PHPUnit, evidenced by errors similar to the following being displayed for a failing testcase:

    4) Interop\Http\Factory\ServerRequestFactoryTest::testCreateServerRequestWithUriObject with data set #3 (array('DELETE', '/test', 'foo=1&bar=true', 'example.org'))
    PHP Notice:  Undefined index: SCRIPT_NAME in phar:///usr/local/bin/phpunit/phpunit/Util/Filter.php on line 29
    PHP Stack trace:
    PHP   1. {main}() /usr/local/bin/phpunit:0
    PHP   2. PHPUnit_TextUI_Command::main() /usr/local/bin/phpunit:569
    PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:113
    PHP   4. PHPUnit_TextUI_TestRunner->doRun() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:162
    PHP   5. PHPUnit_TextUI_ResultPrinter->printResult() phar:///usr/local/bin/phpunit/phpunit/TextUI/TestRunner.php:471
    PHP   6. PHPUnit_TextUI_ResultPrinter->printErrors() phar:///usr/local/bin/phpunit/phpunit/TextUI/ResultPrinter.php:186
    PHP   7. PHPUnit_TextUI_ResultPrinter->printDefects() phar:///usr/local/bin/phpunit/phpunit/TextUI/ResultPrinter.php:281
    PHP   8. PHPUnit_TextUI_ResultPrinter->printDefect() phar:///usr/local/bin/phpunit/phpunit/TextUI/ResultPrinter.php:232
    PHP   9. PHPUnit_TextUI_ResultPrinter->printDefectTrace() phar:///usr/local/bin/phpunit/phpunit/TextUI/ResultPrinter.php:245
    PHP  10. PHPUnit_Framework_Exception->__toString() phar:///usr/local/bin/phpunit/phpunit/TextUI/ResultPrinter.php:269
    PHP  11. PHPUnit_Util_Filter::getFilteredStacktrace() phar:///usr/local/bin/phpunit/phpunit/Framework/Exception.php:66
    Undefined index: HTTP_HOST

    /mnt/web/tests/http/src/ServerRequestFactory.php:127
    /mnt/web/tests/http/src/ServerRequestFactory.php:49
    /mnt/web/tests/http/vendor/http-interop/http-factory-tests/test/ServerRequestFactoryTestCase.php:118
    /usr/local/bin/phpunit:569

The simplest solution is to leverage PHPUnit backing up globals before the individual test, and restoring them after. This results in the following output from a failing testcase.

    4) Interop\Http\Factory\ServerRequestFactoryTest::testCreateServerRequestWithUriObject with data set #3 (array('DELETE', '/test', 'foo=1&bar=true', 'example.org'))
    Undefined index: HTTP_HOST

    /mnt/web/tests/http/src/ServerRequestFactory.php:127
    /mnt/web/tests/http/src/ServerRequestFactory.php:49
    /mnt/web/tests/http/vendor/http-interop/http-factory-tests/test/ServerRequestFactoryTestCase.php:118

**EDIT**
I see that there is a recent pull request #22 adding backupGlobals into the phpunit configuration file in README.md - This is a far more robust solution, as it doesn't depend on specific configurations.