### PR TITLE
Update PHPUnit requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,8 @@
         }
     ],
     "require": {
-        "http-interop/http-factory": "^0.3"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "http-interop/http-factory": "^0.3",
+        "phpunit/phpunit": "^5.7|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/RequestFactoryTestCase.php
+++ b/test/RequestFactoryTestCase.php
@@ -3,7 +3,7 @@
 namespace Interop\Http\Factory;
 
 use Interop\Http\Factory\RequestFactoryInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 

--- a/test/ResponseFactoryTestCase.php
+++ b/test/ResponseFactoryTestCase.php
@@ -3,7 +3,7 @@
 namespace Interop\Http\Factory;
 
 use Interop\Http\Factory\ResponseFactoryInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
 abstract class ResponseFactoryTestCase extends TestCase

--- a/test/ServerRequestFactoryTestCase.php
+++ b/test/ServerRequestFactoryTestCase.php
@@ -3,7 +3,7 @@
 namespace Interop\Http\Factory;
 
 use Interop\Http\Factory\ServerRequestFactoryInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 

--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -3,7 +3,7 @@
 namespace Interop\Http\Factory;
 
 use Interop\Http\Factory\StreamFactoryInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 
 abstract class StreamFactoryTestCase extends TestCase

--- a/test/UploadedFileFactoryTestCase.php
+++ b/test/UploadedFileFactoryTestCase.php
@@ -3,7 +3,7 @@
 namespace Interop\Http\Factory;
 
 use Interop\Http\Factory\UploadedFileFactoryInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UploadedFileInterface;
 
 abstract class UploadedFileFactoryTestCase extends TestCase

--- a/test/UriFactoryTestCase.php
+++ b/test/UriFactoryTestCase.php
@@ -3,7 +3,7 @@
 namespace Interop\Http\Factory;
 
 use Interop\Http\Factory\UriFactoryInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriInterface;
 
 abstract class UriFactoryTestCase extends TestCase


### PR DESCRIPTION
- Updated PHPUnit to allow for PHPUnit ^5.7|^6.0
- Moved PHPUnit to required dependencies since this package is for testing purposes only
- Switched to PHPUnit namespaces, which [are available in 5.7][1], too

[1]: https://github.com/sebastianbergmann/phpunit/blob/5.7/src/ForwardCompatibility/TestCase.php