### PR TITLE
The UploadedFileFactory does not support filenames

### DIFF
--- a/test/UploadedFileFactoryTestCase.php
+++ b/test/UploadedFileFactoryTestCase.php
@@ -45,11 +45,8 @@ abstract class UploadedFileFactoryTestCase extends TestCase
     {
         $content = 'i made this!';
         $size = strlen($content);
-        $filename = $this->createTemporaryFile();
 
-        file_put_contents($filename, $content);
-
-        $file = $this->factory->createUploadedFile($filename);
+        $file = $this->factory->createUploadedFile($content);
 
         $this->assertUploadedFile($file, $content, $size);
     }


### PR DESCRIPTION
If first argument is a string it is considered as the content of the file. 

https://github.com/http-interop/http-factory/blob/master/src/UploadedFileFactoryInterface.php#L12