### PR TITLE
Add support for http-interop/http-factory 1.0.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "http-interop/http-factory": "^0.3",
+        "http-interop/http-factory": "^0.3 || 1.0.x-dev",
         "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0"
     },
     "autoload": {


### PR DESCRIPTION
As of now the http-interop/http-factory updated there interfaces but not yet "released" it. Meaning my tests are not working atm.
By doing this we add support for 1.0.x-dev on http-interop/http-factory.