### PR TITLE
Clean up temporary files

### DIFF
--- a/test/StreamHelper.php
+++ b/test/StreamHelper.php
@@ -4,9 +4,11 @@ namespace Interop\Http\Factory;
 
 trait StreamHelper
 {
+    protected static $tempFiles = [];
+
     protected function createTemporaryFile()
     {
-        return tempnam(sys_get_temp_dir(), uniqid());
+        return static::$tempFiles[] = tempnam(sys_get_temp_dir(), 'http_factory_tests_');
     }
 
     protected function createTemporaryResource($content = null)
@@ -20,5 +22,12 @@ trait StreamHelper
         }
 
         return $resource;
+    }
+
+    public static function tearDownAfterClass()
+    {
+        foreach (static::$tempFiles as $tempFile) {
+            @unlink($tempFile);
+        }
     }
 }


### PR DESCRIPTION
I forgot about this previously. I was running the tests over and over again and really surprised none of the temporary files were getting cleaned up.

Changes:

1. Use a [`tempnam()`](https://secure.php.net/manual/en/function.tempnam.php) `$prefix` specifically for the tests (`http_factory_tests_`). I don’t know why this was using a unique ID previously. The function is already making sure all the temporary file names will be unique. The prefix is there to set them aside from other files in the whatever directory you are using.
   
2. Remove all the files created by `StreamHelper::createTemporaryFile` on [class tear down](https://phpunit.readthedocs.io/en/7.3/fixtures.html#sharing-fixture). That is: after PHPUnit is done running all the stream tests.