### PR TITLE
Add tests for read/write (cursor) position on Stream

### DIFF
--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -156,4 +156,24 @@ abstract class StreamFactoryTestCase extends TestCase
 
         $this->assertStream($stream, $string);
     }
+
+    public function testCreateStreamFromResourceCursorPosition()
+    {
+        $string = 'would you like some crumpets?';
+
+        $resource1 = $this->createTemporaryResource($string);
+        fseek($resource1, 0, SEEK_SET);
+        $stream1 = $this->factory->createStreamFromResource($resource1);
+        $this->assertSame(0, $stream1->tell());
+
+        $resource2 = $this->createTemporaryResource($string);
+        fseek($resource2, 0, SEEK_END);
+        $stream2 = $this->factory->createStreamFromResource($resource2);
+        $this->assertSame(strlen($string), $stream2->tell());
+
+        $resource3 = $this->createTemporaryResource($string);
+        fseek($resource3, 15, SEEK_SET);
+        $stream3 = $this->factory->createStreamFromResource($resource3);
+        $this->assertSame(15, $stream3->tell());
+    }
 }

--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -67,6 +67,17 @@ abstract class StreamFactoryTestCase extends TestCase
         $this->assertStream($stream, $string);
     }
 
+    public function testCreateStreamCursorPosition()
+    {
+        $this->markTestIncomplete('This behaviour has not been specified by PHP-FIG yet.');
+
+        $string = 'would you like some crumpets?';
+
+        $stream = $this->factory->createStream($string);
+
+        $this->assertSame(strlen($string), $stream->tell());
+    }
+
     public function testCreateStreamFromFile()
     {
         $string = 'would you like some crumpets?';

--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -131,6 +131,22 @@ abstract class StreamFactoryTestCase extends TestCase
         $stream = $this->factory->createStreamFromFile($filename, "\u{2620}");
     }
 
+    public function testCreateStreamFromFileCursorPosition()
+    {
+        $string = 'would you like some crumpets?';
+        $filename = $this->createTemporaryFile();
+
+        file_put_contents($filename, $string);
+
+        $resource = fopen($filename, 'r');
+        $fopenTell = ftell($resource);
+        fclose($resource);
+
+        $stream = $this->factory->createStreamFromFile($filename);
+
+        $this->assertSame($fopenTell, $stream->tell());
+    }
+
     public function testCreateStreamFromResource()
     {
         $string = 'would you like some crumpets?';


### PR DESCRIPTION
Having Stream instances with different cursor positions come out of the factories depending on implementation breaks interoperability. Simple example: calling `getContents()` on a factory created Stream can give different results.

This adds tests to check interoperability between implementations. See [<i>[PSR-17] Define where the file position indicator (cursor) ends up to ensure Stream compatibility</i> on the mailing list](https://groups.google.com/forum/#!topic/php-fig/S5YIw-Pu1yM) for more background.

Note that these tests are based on current implementations and not on any strict definitions by the PSR-17 Working Group. This is because nothing is written about file positions at all.

The test for `StreamFactoryInterface::createStream()` is marked as incomplete as there is no clear consensus among implementations. This can either be accepted into this repository as an incomplete test, or can not be merged by omitting 4f49487 from the merge.

Not sure what the policy is on these types of tests. But thought I would get the ball rolling with a PR anyway!