### PR TITLE
proper check instead using the @-operator

### DIFF
--- a/test/StreamHelper.php
+++ b/test/StreamHelper.php
@@ -27,7 +27,7 @@ trait StreamHelper
     public static function tearDownAfterClass(): void
     {
         foreach (static::$tempFiles as $tempFile) {
-            if(file_exists($tempFile)){
+            if (is_file($tempFile)) {
                 unlink($tempFile);
             }
         }

--- a/test/StreamHelper.php
+++ b/test/StreamHelper.php
@@ -27,7 +27,9 @@ trait StreamHelper
     public static function tearDownAfterClass(): void
     {
         foreach (static::$tempFiles as $tempFile) {
-            @unlink($tempFile);
+            if(file_exists($tempFile)){
+                unlink($tempFile);
+            }
         }
     }
 }


### PR DESCRIPTION
Travis doesn't seem to like the `@` operator and throws an error nonetheless.

https://travis-ci.org/chillerlan/php-httpinterface/jobs/506510289#L506 (edit: correct permalink)