### PR TITLE
file mode validation cannot be implemented according to PSR-17

### DIFF
--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -119,7 +119,7 @@ abstract class StreamFactoryTestCase extends TestCase
     {
         $filename = $this->createTemporaryFile();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(Exception::class);
         $stream = $this->factory->createStreamFromFile($filename, '');
     }
 
@@ -127,7 +127,7 @@ abstract class StreamFactoryTestCase extends TestCase
     {
         $filename = $this->createTemporaryFile();
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(Exception::class);
         $stream = $this->factory->createStreamFromFile($filename, "\u{2620}");
     }
 

--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Interop\Http\Factory;
 
+use Exception;
 use InvalidArgumentException;
 use RuntimeException;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
the psr-17 spec requires to have different exceptions for invalid modes and other file opening errors:
```
@throws \RuntimeException If the file cannot be opened.
@throws \InvalidArgumentException If the mode is invalid.
```

How is it expected to be implemented? I can't figure out a way to implement this because the accepted modes depend on the OS. And the error message that are returned also depend on the OS. See https://github.com/guzzle/psr7/pull/274/files#r291236165
On travis for example it say `No such file or directory` although the mode is wrong. So we cannot distinguish between wrong mode or a different failure unless we hardcode the modes. But that would be pointless and would also be against the PSR-17 spec which says it must accept anything that `fopen` can accept. So it can't be hardcoded.
Diactoros also does not seem to implement this behavior. So did anybody find a solution or is the spec not implementable?

Response from Woody Gilk

> yeah that is really bad on our part, i think you should just ignore `InvalidArgumentException` and only deal with `RuntimeException` the `InvalidArgumentException` was intended for packages that *want* to validate the mode
> for instance, if a StreamFactory only wanted to support readable streams, it has the option to throw `InvalidArgumentException` for any mode that is not `$mode = 'r'`