### PR TITLE
allow PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1",
         "psr/http-factory": "^1.0",
-        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0"
+        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi! [PHPUnit 9 has just been released](https://thephp.cc/news/2020/02/migrating-to-phpunit-9) and i'd like to update the `composer.json` to allow it. I already ran the tests successfully on the new PHPUnit version and it looks like there are no further changes required for now.