### PR TITLE
Fix PHP 8.0 expectations for fopen()

### DIFF
--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -92,12 +92,7 @@ abstract class StreamFactoryTestCase extends TestCase
 
     public function testCreateStreamFromInvalidFileName()
     {
-        if (PHP_VERSION_ID >= 80000) {
-             $this->expectException(ValueError::class);
-        }
-        else {
-             $this->expectException(RuntimeException::class);
-        }
+        $this->expectException(PHP_VERSION_ID >= 80000 ? ValueError::class : RuntimeException::class);
         $stream = $this->factory->createStreamFromFile('');
     }
 

--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -8,6 +8,7 @@ use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use ValueError;
 
 abstract class StreamFactoryTestCase extends TestCase
 {
@@ -91,7 +92,12 @@ abstract class StreamFactoryTestCase extends TestCase
 
     public function testCreateStreamFromInvalidFileName()
     {
-        $this->expectException(RuntimeException::class);
+        if (PHP_VERSION_ID >= 80000) {
+             $this->expectException(ValueError::class);
+        }
+        else {
+             $this->expectException(RuntimeException::class);
+        }
         $stream = $this->factory->createStreamFromFile('');
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/http-interop/http-factory-tests/pull/44

The function in 8.0 changed what will be throws when filename is empty and when file not exists
- https://3v4l.org/ehlIs (empty filename)
```
# php -r 'fopen("123.txt", "ro");'
PHP Warning:  fopen(123.txt): Failed to open stream: No such file or directory in Command line code on line 1

Warning: fopen(123.txt): Failed to open stream: No such file or directory in Command line code on line 1
# php -v
PHP 8.0.0RC3 (cli) (built: Oct 28 2020 13:34:07) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.0-dev, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.0RC3, Copyright (c), by Zend Technologies
```

Details could be found in https://php.watch/versions/8.0/internal-function-exceptions

Fixing it helps to pass tests for https://github.com/laminas/laminas-diactoros/pull/46