### PR TITLE
StreamFactoryInterface::createStreamFromFile does NOT throw ValueError on PHP 8

### DIFF
--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -8,7 +8,6 @@ use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
-use ValueError;
 
 abstract class StreamFactoryTestCase extends TestCase
 {
@@ -92,7 +91,7 @@ abstract class StreamFactoryTestCase extends TestCase
 
     public function testCreateStreamFromInvalidFileName()
     {
-        $this->expectException(PHP_VERSION_ID >= 80000 ? ValueError::class : RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $stream = $this->factory->createStreamFromFile('');
     }
 


### PR DESCRIPTION
Follow-up #45 

`fopen` behavior changed with PHP 8, but not PSR-17. Function [StreamFactoryInterface::createStreamFromFile](https://github.com/php-fig/http-factory/blob/master/src/StreamFactoryInterface.php#L33) still NOT throw `ValueError`, but only `RuntimeException` or `InvalidArgumentException`.

This PR revert #45