### PR TITLE
Support PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "psr/http-factory": "^1.0",
-        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/RequestFactoryTestCase.php
+++ b/test/RequestFactoryTestCase.php
@@ -38,7 +38,7 @@ abstract class RequestFactoryTestCase extends TestCase
         $this->assertSame($uri, (string) $request->getUri());
     }
 
-    public function dataMethods()
+    public static function dataMethods()
     {
         return [
             ['GET'],

--- a/test/ResponseFactoryTestCase.php
+++ b/test/ResponseFactoryTestCase.php
@@ -29,7 +29,7 @@ abstract class ResponseFactoryTestCase extends TestCase
         $this->assertSame($code, $response->getStatusCode());
     }
 
-    public function dataCodes()
+    public static function dataCodes()
     {
         return [
             [200],

--- a/test/ServerRequestFactoryTestCase.php
+++ b/test/ServerRequestFactoryTestCase.php
@@ -38,7 +38,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
         $this->assertSame($uri, (string) $request->getUri());
     }
 
-    public function dataMethods()
+    public static function dataMethods()
     {
         return [
             ['GET'],
@@ -50,11 +50,11 @@ abstract class ServerRequestFactoryTestCase extends TestCase
         ];
     }
 
-    public function dataServer()
+    public static function dataServer()
     {
         $data = [];
 
-        foreach ($this->dataMethods() as $methodData) {
+        foreach (static::dataMethods() as $methodData) {
             $data[] = [
                 [
                     'REQUEST_METHOD' => $methodData[0],


### PR DESCRIPTION
This PR adds support for PHPUnit 10. From now on, data providers have to be static methods, which may or may not affect older PHPUnit versions.

Edit: there, saved you some work: https://github.com/codemasher/http-factory-tests/commit/9b5da0944c0e633898af8aa549e1a667b34650e7