### PR TITLE
support PHPUnit 10, PHP 8.1+, cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,14 @@
         {
             "name": "PHP-FIG",
             "homepage": "https://www.php-fig.org/"
+        },
+        {
+            "name": "Contributors",
+            "homepage": "https://github.com/http-interop/http-factory-tests/graphs/contributors"
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "psr/http-factory": "^1.0",
         "phpunit/phpunit": "^10.0"
     },

--- a/test/RequestFactoryTest.php
+++ b/test/RequestFactoryTest.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * @noinspection PhpUndefinedConstantInspection
+ */
 
 namespace Interop\Http\Factory;
+
+use function class_exists;
+use function defined;
 
 final class RequestFactoryTest extends RequestFactoryTestCase
 {
@@ -9,13 +15,11 @@ final class RequestFactoryTest extends RequestFactoryTestCase
      */
     protected function createRequestFactory()
     {
-        if (!defined('REQUEST_FACTORY')) {
-            $this->markTestSkipped('Request factory class name not provided');
+        if (!defined('REQUEST_FACTORY') || !class_exists(REQUEST_FACTORY)) {
+            self::markTestSkipped('Request factory class name not provided');
         }
 
-        $factoryClass = REQUEST_FACTORY;
-
-        return new $factoryClass();
+        return new (REQUEST_FACTORY);
     }
 
     /**
@@ -24,12 +28,9 @@ final class RequestFactoryTest extends RequestFactoryTestCase
     protected function createUri($uri)
     {
         if (!defined('URI_FACTORY')) {
-            $this->markTestSkipped('URI factory class name not provided');
+            self::markTestSkipped('URI factory class name not provided');
         }
 
-        $factoryClass = URI_FACTORY;
-        $uriFactory = new $factoryClass();
-
-        return $uriFactory->createUri($uri);
+        return (new (URI_FACTORY))->createUri($uri);
     }
 }

--- a/test/RequestFactoryTestCase.php
+++ b/test/RequestFactoryTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Interop\Http\Factory;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -33,26 +34,24 @@ abstract class RequestFactoryTestCase extends TestCase
 
     protected function assertRequest($request, $method, $uri)
     {
-        $this->assertInstanceOf(RequestInterface::class, $request);
-        $this->assertSame($method, $request->getMethod());
-        $this->assertSame($uri, (string) $request->getUri());
+        static::assertInstanceOf(RequestInterface::class, $request);
+        static::assertSame($method, $request->getMethod());
+        static::assertSame($uri, (string) $request->getUri());
     }
 
     public static function dataMethods()
     {
         return [
-            ['GET'],
-            ['POST'],
-            ['PUT'],
-            ['DELETE'],
-            ['OPTIONS'],
-            ['HEAD'],
+            'GET'     => ['GET'],
+            'POST'    => ['POST'],
+            'PUT'     => ['PUT'],
+            'DELETE'  => ['DELETE'],
+            'OPTIONS' => ['OPTIONS'],
+            'HEAD'    => ['HEAD'],
         ];
     }
 
-    /**
-     * @dataProvider dataMethods
-     */
+    #[DataProvider('dataMethods')]
     public function testCreateRequest($method)
     {
         $uri = 'http://example.com/';

--- a/test/ResponseFactoryTest.php
+++ b/test/ResponseFactoryTest.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * @noinspection PhpUndefinedConstantInspection
+ */
 
 namespace Interop\Http\Factory;
+
+use function class_exists;
+use function defined;
 
 final class ResponseFactoryTest extends ResponseFactoryTestCase
 {
@@ -9,12 +15,10 @@ final class ResponseFactoryTest extends ResponseFactoryTestCase
      */
     protected function createResponseFactory()
     {
-        if (!defined('RESPONSE_FACTORY')) {
-            $this->markTestSkipped('Response factory class name not provided');
+        if (!defined('RESPONSE_FACTORY') || !class_exists(RESPONSE_FACTORY)) {
+            self::markTestSkipped('Response factory class name not provided');
         }
 
-        $factoryClass = RESPONSE_FACTORY;
-
-        return new $factoryClass();
+        return new (RESPONSE_FACTORY);
     }
 }

--- a/test/ResponseFactoryTestCase.php
+++ b/test/ResponseFactoryTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Interop\Http\Factory;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -25,23 +26,21 @@ abstract class ResponseFactoryTestCase extends TestCase
 
     protected function assertResponse($response, $code)
     {
-        $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertSame($code, $response->getStatusCode());
+        static::assertInstanceOf(ResponseInterface::class, $response);
+        static::assertSame($code, $response->getStatusCode());
     }
 
     public static function dataCodes()
     {
         return [
-            [200],
-            [301],
-            [404],
-            [500],
+            '200' => [200],
+            '301' => [301],
+            '404' => [404],
+            '500' => [500],
         ];
     }
 
-    /**
-     * @dataProvider dataCodes
-     */
+    #[DataProvider('dataCodes')]
     public function testCreateResponse($code)
     {
         $response = $this->factory->createResponse($code);

--- a/test/ServerRequestFactoryTest.php
+++ b/test/ServerRequestFactoryTest.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * @noinspection PhpUndefinedConstantInspection
+ */
 
 namespace Interop\Http\Factory;
+
+use function class_exists;
+use function defined;
 
 final class ServerRequestFactoryTest extends ServerRequestFactoryTestCase
 {
@@ -9,13 +15,11 @@ final class ServerRequestFactoryTest extends ServerRequestFactoryTestCase
      */
     protected function createServerRequestFactory()
     {
-        if (!defined('SERVER_REQUEST_FACTORY')) {
-            $this->markTestSkipped('Server Request factory class name not provided');
+        if (!defined('SERVER_REQUEST_FACTORY') || !class_exists(SERVER_REQUEST_FACTORY)) {
+            self::markTestSkipped('Server Request factory class name not provided');
         }
 
-        $factoryClass = SERVER_REQUEST_FACTORY;
-
-        return new $factoryClass();
+        return new (SERVER_REQUEST_FACTORY);
     }
 
     /**
@@ -24,12 +28,9 @@ final class ServerRequestFactoryTest extends ServerRequestFactoryTestCase
     protected function createUri($uri)
     {
         if (!defined('URI_FACTORY')) {
-            $this->markTestSkipped('URI factory class name not provided');
+            self::markTestSkipped('URI factory class name not provided');
         }
 
-        $factoryClass = URI_FACTORY;
-        $uriFactory = new $factoryClass();
-
-        return $uriFactory->createUri($uri);
+        return (new (URI_FACTORY))->createUri($uri);
     }
 }

--- a/test/ServerRequestFactoryTestCase.php
+++ b/test/ServerRequestFactoryTestCase.php
@@ -1,11 +1,17 @@
 <?php
+/**
+ * @noinspection PhpArrayWriteIsNotUsedInspection
+ */
 
 namespace Interop\Http\Factory;
 
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
+use const UPLOAD_ERR_OK;
 
 abstract class ServerRequestFactoryTestCase extends TestCase
 {
@@ -33,9 +39,9 @@ abstract class ServerRequestFactoryTestCase extends TestCase
 
     protected function assertServerRequest($request, $method, $uri)
     {
-        $this->assertInstanceOf(ServerRequestInterface::class, $request);
-        $this->assertSame($method, $request->getMethod());
-        $this->assertSame($uri, (string) $request->getUri());
+        static::assertInstanceOf(ServerRequestInterface::class, $request);
+        static::assertSame($method, $request->getMethod());
+        static::assertSame($uri, (string) $request->getUri());
     }
 
     public static function dataMethods()
@@ -55,7 +61,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
         $data = [];
 
         foreach (static::dataMethods() as $methodData) {
-            $data[] = [
+            $data[$methodData[0]] = [
                 [
                     'REQUEST_METHOD' => $methodData[0],
                     'REQUEST_URI' => '/test',
@@ -68,9 +74,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
         return $data;
     }
 
-    /**
-     * @dataProvider dataServer
-     */
+    #[DataProvider('dataServer')]
     public function testCreateServerRequest($server)
     {
         $method = $server['REQUEST_METHOD'];
@@ -81,9 +85,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
         $this->assertServerRequest($request, $method, $uri);
     }
 
-    /**
-     * @dataProvider dataServer
-     */
+    #[DataProvider('dataServer')]
     public function testCreateServerRequestFromArray(array $server)
     {
         $method = $server['REQUEST_METHOD'];
@@ -94,9 +96,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
         $this->assertServerRequest($request, $method, $uri);
     }
 
-    /**
-     * @dataProvider dataServer
-     */
+    #[DataProvider('dataServer')]
     public function testCreateServerRequestWithUriObject($server)
     {
         $method = $server['REQUEST_METHOD'];
@@ -107,9 +107,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
         $this->assertServerRequest($request, $method, $uri);
     }
 
-    /**
-     * @backupGlobals enabled
-     */
+    #[BackupGlobals(true)]
     public function testCreateServerRequestDoesNotReadServerSuperglobal()
     {
         $_SERVER = ['HTTP_X_FOO' => 'bar'];
@@ -125,8 +123,8 @@ abstract class ServerRequestFactoryTestCase extends TestCase
 
         $serverParams = $request->getServerParams();
 
-        $this->assertNotEquals($_SERVER, $serverParams);
-        $this->assertArrayNotHasKey('HTTP_X_FOO', $serverParams);
+        static::assertNotEquals($_SERVER, $serverParams);
+        static::assertArrayNotHasKey('HTTP_X_FOO', $serverParams);
     }
 
     public function testCreateServerRequestDoesNotReadCookieSuperglobal()
@@ -135,7 +133,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
 
         $request = $this->factory->createServerRequest('POST', 'http://example.org/test');
 
-        $this->assertEmpty($request->getCookieParams());
+        static::assertEmpty($request->getCookieParams());
     }
 
     public function testCreateServerRequestDoesNotReadGetSuperglobal()
@@ -144,7 +142,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
 
         $request = $this->factory->createServerRequest('POST', 'http://example.org/test');
 
-        $this->assertEmpty($request->getQueryParams());
+        static::assertEmpty($request->getQueryParams());
     }
 
     public function testCreateServerRequestDoesNotReadFilesSuperglobal()
@@ -153,7 +151,7 @@ abstract class ServerRequestFactoryTestCase extends TestCase
 
         $request = $this->factory->createServerRequest('POST', 'http://example.org/test');
 
-        $this->assertEmpty($request->getUploadedFiles());
+        static::assertEmpty($request->getUploadedFiles());
     }
 
     public function testCreateServerRequestDoesNotReadPostSuperglobal()
@@ -162,6 +160,6 @@ abstract class ServerRequestFactoryTestCase extends TestCase
 
         $request = $this->factory->createServerRequest('POST', 'http://example.org/test');
 
-        $this->assertEmpty($request->getParsedBody());
+        static::assertEmpty($request->getParsedBody());
     }
 }

--- a/test/StreamFactoryTest.php
+++ b/test/StreamFactoryTest.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * @noinspection PhpUndefinedConstantInspection
+ */
 
 namespace Interop\Http\Factory;
+
+use function class_exists;
+use function defined;
 
 final class StreamFactoryTest extends StreamFactoryTestCase
 {
@@ -9,12 +15,10 @@ final class StreamFactoryTest extends StreamFactoryTestCase
      */
     protected function createStreamFactory()
     {
-        if (!defined('STREAM_FACTORY')) {
-            $this->markTestSkipped('Stream factory class name not provided');
+        if (!defined('STREAM_FACTORY') || !class_exists(STREAM_FACTORY)) {
+            self::markTestSkipped('Stream factory class name not provided');
         }
 
-        $factoryClass = STREAM_FACTORY;
-
-        return new $factoryClass();
+        return new (STREAM_FACTORY);
     }
 }

--- a/test/StreamFactoryTestCase.php
+++ b/test/StreamFactoryTestCase.php
@@ -3,11 +3,19 @@
 namespace Interop\Http\Factory;
 
 use Exception;
-use InvalidArgumentException;
 use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
+use function fclose;
+use function file_put_contents;
+use function fopen;
+use function fseek;
+use function ftell;
+use function strlen;
+use function unlink;
+use const SEEK_END;
+use const SEEK_SET;
 
 abstract class StreamFactoryTestCase extends TestCase
 {
@@ -30,8 +38,8 @@ abstract class StreamFactoryTestCase extends TestCase
 
     protected function assertStream($stream, $content)
     {
-        $this->assertInstanceOf(StreamInterface::class, $stream);
-        $this->assertSame($content, (string) $stream);
+        static::assertInstanceOf(StreamInterface::class, $stream);
+        static::assertSame($content, (string) $stream);
     }
 
     public function testCreateStreamWithoutArgument()
@@ -68,6 +76,9 @@ abstract class StreamFactoryTestCase extends TestCase
         $this->assertStream($stream, $string);
     }
 
+    /**
+     * @noinspection PhpUnreachableStatementInspection
+     */
     public function testCreateStreamCursorPosition()
     {
         $this->markTestIncomplete('This behaviour has not been specified by PHP-FIG yet.');
@@ -76,7 +87,7 @@ abstract class StreamFactoryTestCase extends TestCase
 
         $stream = $this->factory->createStream($string);
 
-        $this->assertSame(strlen($string), $stream->tell());
+        static::assertSame(strlen($string), $stream->tell());
     }
 
     public function testCreateStreamFromFile()
@@ -97,13 +108,13 @@ abstract class StreamFactoryTestCase extends TestCase
         unlink($filename);
 
         $this->expectException(RuntimeException::class);
-        $stream = $this->factory->createStreamFromFile($filename);
+        $this->factory->createStreamFromFile($filename);
     }
 
     public function testCreateStreamFromInvalidFileName()
     {
         $this->expectException(RuntimeException::class);
-        $stream = $this->factory->createStreamFromFile('');
+        $this->factory->createStreamFromFile('');
     }
 
     public function testCreateStreamFromFileIsReadOnlyByDefault()
@@ -132,7 +143,7 @@ abstract class StreamFactoryTestCase extends TestCase
         $filename = $this->createTemporaryFile();
 
         $this->expectException(Exception::class);
-        $stream = $this->factory->createStreamFromFile($filename, '');
+        $this->factory->createStreamFromFile($filename, '');
     }
 
     public function testCreateStreamFromFileWithInvalidMode()
@@ -140,7 +151,7 @@ abstract class StreamFactoryTestCase extends TestCase
         $filename = $this->createTemporaryFile();
 
         $this->expectException(Exception::class);
-        $stream = $this->factory->createStreamFromFile($filename, "\u{2620}");
+        $this->factory->createStreamFromFile($filename, "\u{2620}");
     }
 
     public function testCreateStreamFromFileCursorPosition()
@@ -156,7 +167,7 @@ abstract class StreamFactoryTestCase extends TestCase
 
         $stream = $this->factory->createStreamFromFile($filename);
 
-        $this->assertSame($fopenTell, $stream->tell());
+        static::assertSame($fopenTell, $stream->tell());
     }
 
     public function testCreateStreamFromResource()
@@ -176,16 +187,16 @@ abstract class StreamFactoryTestCase extends TestCase
         $resource1 = $this->createTemporaryResource($string);
         fseek($resource1, 0, SEEK_SET);
         $stream1 = $this->factory->createStreamFromResource($resource1);
-        $this->assertSame(0, $stream1->tell());
+        static::assertSame(0, $stream1->tell());
 
         $resource2 = $this->createTemporaryResource($string);
         fseek($resource2, 0, SEEK_END);
         $stream2 = $this->factory->createStreamFromResource($resource2);
-        $this->assertSame(strlen($string), $stream2->tell());
+        static::assertSame(strlen($string), $stream2->tell());
 
         $resource3 = $this->createTemporaryResource($string);
         fseek($resource3, 15, SEEK_SET);
         $stream3 = $this->factory->createStreamFromResource($resource3);
-        $this->assertSame(15, $stream3->tell());
+        static::assertSame(15, $stream3->tell());
     }
 }

--- a/test/StreamHelper.php
+++ b/test/StreamHelper.php
@@ -2,13 +2,30 @@
 
 namespace Interop\Http\Factory;
 
+use RuntimeException;
+use function fopen;
+use function fwrite;
+use function is_file;
+use function rewind;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
 trait StreamHelper
 {
     protected static $tempFiles = [];
 
     protected function createTemporaryFile()
     {
-        return static::$tempFiles[] = tempnam(sys_get_temp_dir(), 'http_factory_tests_');
+        $file = tempnam(sys_get_temp_dir(), 'http_factory_tests_');
+
+        if($file === false){
+            throw new RuntimeException('could not create temp file');
+        }
+
+        static::$tempFiles[] = $file;
+
+        return $file;
     }
 
     protected function createTemporaryResource($content = null)

--- a/test/UploadedFileFactoryTest.php
+++ b/test/UploadedFileFactoryTest.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * @noinspection PhpUndefinedConstantInspection
+ */
 
 namespace Interop\Http\Factory;
+
+use function class_exists;
+use function defined;
 
 final class UploadedFileFactoryTest extends UploadedFileFactoryTestCase
 {
@@ -9,24 +15,19 @@ final class UploadedFileFactoryTest extends UploadedFileFactoryTestCase
      */
     protected function createUploadedFileFactory()
     {
-        if (!defined('UPLOADED_FILE_FACTORY')) {
-            $this->markTestSkipped('Uploaded File factory class name not provided');
+        if (!defined('UPLOADED_FILE_FACTORY') || !class_exists(UPLOADED_FILE_FACTORY)) {
+            self::markTestSkipped('Uploaded File factory class name not provided');
         }
 
-        $factoryClass = UPLOADED_FILE_FACTORY;
-
-        return new $factoryClass();
+        return new (UPLOADED_FILE_FACTORY);
     }
 
     protected function createStream($content)
     {
         if (!defined('STREAM_FACTORY')) {
-            $this->markTestSkipped('STREAM factory class name not provided');
+            self::markTestSkipped('STREAM factory class name not provided');
         }
 
-        $factoryClass = STREAM_FACTORY;
-        $uriFactory = new $factoryClass();
-
-        return $uriFactory->createStream($content);
+        return (new (STREAM_FACTORY))->createStream($content);
     }
 }

--- a/test/UploadedFileFactoryTestCase.php
+++ b/test/UploadedFileFactoryTestCase.php
@@ -6,6 +6,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use function strlen;
+use const UPLOAD_ERR_NO_FILE;
+use const UPLOAD_ERR_OK;
 
 abstract class UploadedFileFactoryTestCase extends TestCase
 {
@@ -37,12 +40,12 @@ abstract class UploadedFileFactoryTestCase extends TestCase
         $clientFilename = null,
         $clientMediaType = null
     ) {
-        $this->assertInstanceOf(UploadedFileInterface::class, $file);
-        $this->assertSame($content, (string) $file->getStream());
-        $this->assertSame($size ?: strlen($content), $file->getSize());
-        $this->assertSame($error ?: UPLOAD_ERR_OK, $file->getError());
-        $this->assertSame($clientFilename, $file->getClientFilename());
-        $this->assertSame($clientMediaType, $file->getClientMediaType());
+        static::assertInstanceOf(UploadedFileInterface::class, $file);
+        static::assertSame($content, (string) $file->getStream());
+        static::assertSame(($size ?? strlen($content)), $file->getSize());
+        static::assertSame(($error ?? UPLOAD_ERR_OK), $file->getError());
+        static::assertSame($clientFilename, $file->getClientFilename());
+        static::assertSame($clientMediaType, $file->getClientMediaType());
     }
 
     public function testCreateUploadedFileWithClientFilenameAndMediaType()
@@ -67,7 +70,7 @@ abstract class UploadedFileFactoryTestCase extends TestCase
 
         // Cannot use assertUploadedFile() here because the error prevents
         // fetching the content stream.
-        $this->assertInstanceOf(UploadedFileInterface::class, $file);
-        $this->assertSame($error, $file->getError());
+        static::assertInstanceOf(UploadedFileInterface::class, $file);
+        static::assertSame($error, $file->getError());
     }
 }

--- a/test/UriFactoryTest.php
+++ b/test/UriFactoryTest.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * @noinspection PhpUndefinedConstantInspection
+ */
 
 namespace Interop\Http\Factory;
+
+use function class_exists;
+use function defined;
 
 final class UriFactoryTest extends UriFactoryTestCase
 {
@@ -9,12 +15,10 @@ final class UriFactoryTest extends UriFactoryTestCase
      */
     protected function createUriFactory()
     {
-        if (!defined('URI_FACTORY')) {
-            $this->markTestSkipped('URI factory class name not provided');
+        if (!defined('URI_FACTORY') || !class_exists(URI_FACTORY)) {
+            self::markTestSkipped('URI factory class name not provided');
         }
 
-        $factoryClass = URI_FACTORY;
-
-        return new $factoryClass();
+        return new (URI_FACTORY);
     }
 }

--- a/test/UriFactoryTestCase.php
+++ b/test/UriFactoryTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Interop\Http\Factory;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
@@ -25,8 +26,8 @@ abstract class UriFactoryTestCase extends TestCase
 
     protected function assertUri($uri, $uriString)
     {
-        $this->assertInstanceOf(UriInterface::class, $uri);
-        $this->assertSame($uriString, (string) $uri);
+        static::assertInstanceOf(UriInterface::class, $uri);
+        static::assertSame($uriString, (string) $uri);
     }
 
     public function testCreateUri()
@@ -40,7 +41,7 @@ abstract class UriFactoryTestCase extends TestCase
 
     public function testExceptionWhenUriIsInvalid()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->factory->createUri(':');
     }
 }


### PR DESCRIPTION
So that's the cleanup PR mentioned in #47. It removes the random abstract classes and traits, updates to some modern PHPUnit features (e.g. data provider calls via attributes) and generally some "modern" PHP features such as typed properties.